### PR TITLE
franz: Proper fix PKGBUILD for build both versions

### DIFF
--- a/aur/franz/PKGBUILD
+++ b/aur/franz/PKGBUILD
@@ -31,6 +31,6 @@ package() {
     install -d ${pkgdir}/{opt/franz,usr/{bin,share/pixmaps}}
     cp -R ${srcdir}/${_path}/* ${pkgdir}/opt/${pkgname}/
     install -Dm755 $srcdir/${pkgname}.sh ${pkgdir}/usr/bin/${pkgname}
-    install -Dm755 $srcdir/${pkgname}.png ${pkgdir}/usr/share/pixmaps/franz.png
+    install -Dm644 $srcdir/${pkgname}.png ${pkgdir}/usr/share/pixmaps/franz.png
     desktop-file-install ${srcdir}/${pkgname}.desktop --dir ${pkgdir}/usr/share/applications/
 }

--- a/aur/franz/PKGBUILD
+++ b/aur/franz/PKGBUILD
@@ -3,50 +3,34 @@
 pkgname=franz
 pkgver=0.9.10
 _gittag=2.0
-pkgrel=3
-pkgdesc="A free messaging app for WhatsApp, Facebook Messenger, Telegram, Slack and more."
+pkgrel=4
+pkgdesc='A free messaging app for WhatsApp, Facebook Messenger, Telegram, Slack and more.'
 arch=('i686' 'x86_64')
-depends=('gconf')
-url="http://meetfranz.com/"
-license=("custom:github")
-
-#Sources
-source=("$pkgname.sh" "$pkgname.desktop" "$pkgname.png")
-source_i686=('https://github.com/imprecision/franz-app/releases/download/'$_gittag'/Franz-linux-ia32-'$pkgver'.tgz')
-source_x86_64=('https://github.com/imprecision/franz-app/releases/download/'$_gittag'/Franz-linux-x64-'$pkgver'.tgz')
-#Checksums
+depends=('alsa-lib' 'bash' 'desktop-file-utils' 'gconf' 'gtk2' 'libnotify' 'libxtst' 'nss')
+makedepends=('tar')
+url='http://meetfranz.com/'
+license=('custom:github')
+source=("${pkgname}.sh" "${pkgname}.desktop" "${pkgname}.png")
+source_i686=("https://github.com/imprecision/franz-app/releases/download/$_gittag/Franz-linux-ia32-$pkgver.tgz")
+source_x86_64=("https://github.com/imprecision/franz-app/releases/download/$_gittag/Franz-linux-x64-$pkgver.tgz")
 sha256sums=('5d53c349bcf0452a31e3aee609eac6809f26750f4fb4da049132adc5c9a40289'
-            '331918823545ad2696a7fb1c8650f1d001be6dfe40f09dd430dee0e4e3f34594'
+            'c63052b7ada73dbc984f55afc6d0ad937bf57ae5b0b41b560ef46937afeb81c5'
             '6e761371afadf155b8bc25e94fd7de371c16130a87338300e5800924916a7a28')
 sha256sums_i686=('9a4ca6e06339b4a01f644fd081b0c1bb8eb3a4e5b8dc8e1c65e09e667b2547c9')
 sha256sums_x86_64=('3bcd64f01ddd2f5bd723d3fd04524eddc3fd11a3c53c95acc0029bb46d11042a')
+[[ "$CARCH" = "i686" ]] && _path="Franz-linux-ia32-${pkgver}"
+[[ "$CARCH" = "x86_64" ]] && _path="Franz-linux-x64-${pkgver}"
+noextract=(${_path})
+
+prepare() {
+    install -d ${srcdir}/${_path}/
+    tar xf "${srcdir}/${_path}.tgz" -C "${srcdir}/${_path}"
+}
 
 package() {
-
-	cd "$srcdir/"
-
-	# Creating needed directories
-	install -dm755 "$pkgdir/opt/franz/"
-	install -dm755 "$pkgdir/usr/bin"
-	install -dm755 "$pkgdir/usr/share/pixmaps/"
-	install -dm755 "$pkgdir/usr/share/applications/"
-
-  # Program
-	cp -r "$srcdir/locales" "$pkgdir/opt/franz/"
-	cp -r "$srcdir/resources" "$pkgdir/opt/franz"
-	install -Dm644 "$srcdir/content_shell.pak" "$pkgdir/opt/franz/"
-	install -Dm755 "$srcdir/Franz" "$pkgdir/opt/franz/"
-	install -Dm644 "$srcdir/icudtl.dat" "$pkgdir/opt/franz/"
-	install -Dm644 "$srcdir/libffmpeg.so" "$pkgdir/opt/franz/"
-	install -Dm644 "$srcdir/libgcrypt.so.11" "$pkgdir/opt/franz/"
-	install -Dm755 "$srcdir/libnode.so" "$pkgdir/opt/franz/"
-	install -Dm644 "$srcdir/natives_blob.bin" "$pkgdir/opt/franz/"
-	install -Dm644 "$srcdir/snapshot_blob.bin" "$pkgdir/opt/franz/"
-
-	# Shell wrapper
-	install -Dm755 "$srcdir/$pkgname.sh" "$pkgdir/usr/bin/franz"
-
-	# Desktop launcher
-	install -Dm755 "$srcdir/$pkgname.png" "$pkgdir/usr/share/pixmaps/franz.png"
-	install -Dm755 "$srcdir/$pkgname.desktop" "$pkgdir/usr/share/applications/franz.desktop"
+    install -d ${pkgdir}/{opt/franz,usr/{bin,share/pixmaps}}
+    cp -R ${srcdir}/${_path}/* ${pkgdir}/opt/${pkgname}/
+    install -Dm755 $srcdir/${pkgname}.sh ${pkgdir}/usr/bin/${pkgname}
+    install -Dm755 $srcdir/${pkgname}.png ${pkgdir}/usr/share/pixmaps/franz.png
+    desktop-file-install ${srcdir}/${pkgname}.desktop --dir ${pkgdir}/usr/share/applications/
 }

--- a/aur/franz/franz.desktop
+++ b/aur/franz/franz.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Encoding=UTF-8
-Version=0.9.9
 Name=Franz
 Comment=A free messaging app for WhatsApp, Facebook Messenger, Telegram, Slack and more.
 Exec=franz -- %u


### PR DESCRIPTION
@ayr-ton Hi. I found Your PKGBUILD and I want make it better. Here is the simplest and valid changes for build `franz` package on Arch Linux.
IDK what exactly license is used in this project (I found only HTML file with chromium license).

Best Regards

Tomasz "FadeMind"