### PR TITLE
changed to version 3.0.2 - solves memory leaks in version 3.0.0

### DIFF
--- a/aur/franz/PKGBUILD
+++ b/aur/franz/PKGBUILD
@@ -1,8 +1,8 @@
 #Maintainer: Ayrton Araujo <root@ayr-ton.net>
 
 pkgname=franz
-pkgver=3.0.0
-_gittag=3.0.0
+pkgver=3.0.2
+_gittag=3.0.2
 pkgrel=1
 pkgdesc='A free messaging app for WhatsApp, Facebook Messenger, Telegram, Slack and more.'
 arch=('i686' 'x86_64')
@@ -16,8 +16,8 @@ source_x86_64=("https://github.com/imprecision/franz-app/releases/download/$_git
 sha256sums=('5d53c349bcf0452a31e3aee609eac6809f26750f4fb4da049132adc5c9a40289'
             'c63052b7ada73dbc984f55afc6d0ad937bf57ae5b0b41b560ef46937afeb81c5'
             '6e761371afadf155b8bc25e94fd7de371c16130a87338300e5800924916a7a28')
-sha256sums_i686=('33a030644e20b13406eec5369f070597f8b6940df14c7bc70e1d204a39a21873')
-sha256sums_x86_64=('61b60fde3ef951e8f99b3deae992195994300b13da368cd999fc332c8023b0d1')
+sha256sums_i686=('19015503b5fce1509649e036bdd21866c490bc237778f6729566edaa2cc942f7')
+sha256sums_x86_64=('67f1f0b673e8b765e0dc15b11829ab7f0f3c83d284f70bbe8b74f7e322706a88')
 [[ "$CARCH" = "i686" ]] && _path="Franz-linux-ia32-${pkgver}"
 [[ "$CARCH" = "x86_64" ]] && _path="Franz-linux-x64-${pkgver}"
 noextract=(${_path})


### PR DESCRIPTION
I had an issue of memory leaking on one of the thread of Franz (the one created as `zigote`). I opened a ticket and it was told me that is solved in this version (3.0.2).